### PR TITLE
adding a test for unsetting the model name.

### DIFF
--- a/tests/model/model.cpp
+++ b/tests/model/model.cpp
@@ -23,6 +23,21 @@ TEST(Model, name) {
     EXPECT_EQ(e, m.serialise(libcellml::CELLML_FORMAT_XML));
 }
 
+TEST(Model, unset_name) {
+    const std::string eName = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<model xmlns=\"http://www.cellml.org/cellml/1.2#\" name=\"name\"></model>";
+    const std::string e = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<model xmlns=\"http://www.cellml.org/cellml/1.2#\"></model>";
+
+    libcellml::Model m = libcellml::Model();
+    std::string n = "name";
+    m.setName(n);
+    EXPECT_EQ("name", m.getName());
+    EXPECT_EQ(eName, m.serialise(libcellml::CELLML_FORMAT_XML));
+
+    m.setName("");
+    EXPECT_EQ("", m.getName());
+    EXPECT_EQ(e, m.serialise(libcellml::CELLML_FORMAT_XML));
+}
+
 TEST(Model, invalid_name) {
     const std::string e = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<model xmlns=\"http://www.cellml.org/cellml/1.2#\" name=\"invalid name\"></model>";
 


### PR DESCRIPTION
 I would expect setting the name to the empty string would result in the name attribute not being present in the XML serialisation.
