### PR TITLE
Windows compile and new tests

### DIFF
--- a/src/component.cpp
+++ b/src/component.cpp
@@ -17,6 +17,7 @@ limitations under the License.
 #include "libcellml/component.h"
 
 #include <algorithm>
+#include <iterator>
 #include <numeric>
 #include <string>
 #include <vector>

--- a/tests/component/component.cpp
+++ b/tests/component/component.cpp
@@ -396,6 +396,20 @@ TEST(Component, takeComponentMethods)
     EXPECT_EQ(e, a);
 }
 
+TEST(Component, addComponentMultipleTimes)
+{
+    auto model = libcellml::Model::create("model");
+    auto tomato = libcellml::Component::create("tomato");
+
+    EXPECT_TRUE(model->addComponent(tomato));
+    EXPECT_TRUE(model->addComponent(tomato));
+
+    auto apple = model->takeComponent("tomato");
+    apple->setName("apple");
+    EXPECT_EQ("apple", model->component(0)->name());
+    EXPECT_EQ("apple", tomato->name());
+}
+
 TEST(Component, replaceComponentMethods)
 {
     const std::string e_orig =
@@ -570,6 +584,11 @@ TEST(Component, addVariableMultipleTimes)
     EXPECT_TRUE(apple->addVariable(pip));
     EXPECT_EQ(size_t(1), tomato->variableCount());
     EXPECT_EQ(size_t(1), apple->variableCount());
+
+    // check some names
+    pip->setName("not_a_pip");
+    EXPECT_EQ("not_a_pip", tomato->variable(0)->name());
+    EXPECT_EQ("not_a_pip", apple->variable(0)->name());
 }
 
 TEST(Component, preventSegfaultInAddSomething)


### PR DESCRIPTION
A simple fix for a windows compilation issue.

Adding a couple of tests to demonstrate the kind of funky behaviour that the multiple add provides. I think its useful to ensure this behaviour is tested so that we can't break it in future without choosing to.