### PR TITLE
Demonstrate a potential bug in the testing for cyclical imports.

### DIFF
--- a/tests/importer/importer.cpp
+++ b/tests/importer/importer.cpp
@@ -94,6 +94,19 @@ TEST(Importer, warningCircularImportReferencesUnits)
     EXPECT_EQ(errorMessage, importer->error(0)->description());
 }
 
+TEST(Importer, importingCommonUnitsDefinitions)
+{
+    auto parser = libcellml::Parser::create();
+    auto importer = libcellml::Importer::create();
+    auto model = parser->parseModel(fileContents("importer/common_units_import_1.xml"));
+    EXPECT_EQ(size_t(0), parser->issueCount());
+    importer->resolveImports(model, resourcePath("importer/"));
+    EXPECT_EQ(size_t(0), importer->issueCount());
+    EXPECT_EQ(size_t(0), importer->errorCount());
+    printIssues(importer);
+}
+
+
 TEST(Importer, warningUnrequiredCircularDependencyComponent)
 {
     auto parser = libcellml::Parser::create();

--- a/tests/resources/importer/common_units_import_1.xml
+++ b/tests/resources/importer/common_units_import_1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?><model xmlns="http://www.cellml.org/cellml/2.0#" xmlns:cellml="http://www.cellml.org/cellml/2.0#" xmlns:xlink="http://www.w3.org/1999/xlink" name="common_units_import_1">
+  
+  <import xlink:href="common_units_import_units.xml">
+    <units name="ms" units_ref="ms"/>
+    <units name="uA_per_cmsq" units_ref="uA_per_cmsq"/>
+	<units name="mV" units_ref="mV"/>
+  </import>
+  <import xlink:href="common_units_import_2.xml">
+    <component name="component_in_model_1" component_ref="component_in_model_2"/>
+  </import>
+
+  <component name="params">
+    <variable name="stimPeriod" initial_value="50" units="ms" interface="public"/>
+    <variable name="stimDuration" initial_value="0.5" units="ms" interface="public"/>
+    <variable name="stimCurrent" initial_value="-10.0" units="uA_per_cmsq" interface="public"/>
+  </component>
+
+</model>

--- a/tests/resources/importer/common_units_import_2.xml
+++ b/tests/resources/importer/common_units_import_2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?><model xmlns="http://www.cellml.org/cellml/2.0#" xmlns:cellml="http://www.cellml.org/cellml/2.0#" xmlns:xlink="http://www.w3.org/1999/xlink" name="common_units_import_2">
+  
+  <import xlink:href="common_units_import_units.xml">
+    <units name="mV" units_ref="mV"/>
+    <units name="ms" units_ref="ms"/>
+    <units name="uA_per_cmsq" units_ref="uA_per_cmsq"/>
+    <units name="mS_per_cmsq" units_ref="mS_per_cmsq"/>
+    <units name="uF_per_cmsq" units_ref="uF_per_cmsq"/>
+  </import>
+  <component name="component_in_model_2">
+    <variable name="V_initial" units="mV" interface="public_and_private"/>
+    <variable name="Istim" units="uA_per_cmsq" interface="public_and_private"/>
+    <variable name="INa" units="uA_per_cmsq" interface="public_and_private"/>
+    <variable name="IK" units="uA_per_cmsq" interface="public_and_private"/>
+    <variable name="Ileak" units="uA_per_cmsq" interface="public_and_private"/>
+    <variable name="h" units="dimensionless" interface="public_and_private"/>
+    <variable name="m" units="dimensionless" interface="public_and_private"/>
+    <variable name="n" units="dimensionless" interface="public_and_private"/>
+    <variable name="V" units="mV" initial_value="V_initial" interface="public_and_private"/>
+    <variable name="minus_V" units="mV" interface="public_and_private"/>
+    <variable name="VNa" units="mV" interface="public_and_private"/>
+    <variable name="VK" units="mV" interface="public_and_private"/>
+    <variable name="Vleak" units="mV" interface="public_and_private"/>
+    <variable name="gNa_max" units="mS_per_cmsq" interface="public_and_private"/>
+    <variable name="gK_max" units="mS_per_cmsq" interface="public_and_private"/>
+    <variable name="gleak_max" units="mS_per_cmsq" interface="public_and_private"/>
+    <variable name="Cm" units="uF_per_cmsq" interface="public_and_private"/>
+    <variable name="time" units="ms" interface="public_and_private"/>
+  </component>
+</model>

--- a/tests/resources/importer/common_units_import_units.xml
+++ b/tests/resources/importer/common_units_import_units.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?><model xmlns="http://www.cellml.org/cellml/2.0#" xmlns:cellml="http://www.cellml.org/cellml/2.0#" xmlns:xlink="http://www.w3.org/1999/xlink" name="common_units">
+  <units name="ms">
+    <unit units="second" prefix="milli"/>
+  </units>
+  <units name="per_ms">
+    <unit units="ms" exponent="-1"/>
+  </units>
+  <units name="per_ms_mV">
+    <unit units="ms" exponent="-1"/>
+    <unit units="mV" exponent="-1"/>
+  </units>
+  <units name="mV">
+    <unit units="volt" prefix="milli"/>
+  </units>
+  <units name="mV_per_ms">
+    <unit units="mV"/>
+    <unit units="ms" exponent="-1"/>
+  </units>
+  <units name="cm">
+    <unit units="metre" prefix="centi"/>
+  </units>
+  <units name="uA">
+    <unit units="ampere" prefix="micro"/>
+  </units>
+  <units name="uA_per_cmsq">
+    <unit units="uA"/>
+    <unit units="cm" exponent="-2"/>
+  </units>
+  <units name="mS">
+    <unit units="siemens" prefix="milli"/>
+  </units>
+  <units name="mS_per_cmsq">
+    <unit units="mS"/>
+    <unit units="cm" exponent="-2"/>
+  </units>
+  <units name="uF">
+    <unit units="farad" prefix="micro"/>
+  </units>
+  <units name="uF_per_cmsq">
+    <unit units="uF"/>
+    <unit units="cm" exponent="-2"/>
+  </units>
+</model>


### PR DESCRIPTION
Adding a new test which has two models which import the same common units definitions and then one
of the models also imports the other model. This results in an cyclical import error reported when
the importer resolves the imports. The error message is wrong in that it refers to components as
units; and also wrong in that as far as I can tell there is no cycle in the imported units.

The test models added are the minimal demonstration of this that I've reduced from an actual model.
Reducing further (e.g., fewer variables, or only importing a subset of the units) results in different
behaviour, which is possibly a different issue.